### PR TITLE
Migrate from v1 embedding to v2 embedding

### DIFF
--- a/android/src/main/java/co/techFlow/auto_start_flutter/AutoStartFlutterPlugin.java
+++ b/android/src/main/java/co/techFlow/auto_start_flutter/AutoStartFlutterPlugin.java
@@ -6,7 +6,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.BinaryMessenger;


### PR DESCRIPTION
Remove PluginRegistry.Registrar import to allow compilation on Flutter > 3.29. Closes #23