### PR TITLE
Fix bad namespace for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "co.techFlow.auto_start_flutter"
     compileSdkVersion 35
 
     defaultConfig {


### PR DESCRIPTION
Fix:
- https://github.com/seena98/auto_start_flutter/issues/22

Error:
```console
* What went wrong: A problem occurred configuring project ':auto_start_flutter'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file: /Users/danielgomez/.pub-cache/hosted/pub.dev/auto_start_flutter-0.1.3/android/build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.
````